### PR TITLE
Ability to disable reCAPTCHA for testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ Add ServiceProvider to the providers array in `app/config/app.php`.
 ### Configuration
 Run `php artisan config:publish anhskohbo/no-captcha` (`publish:config` if you use Laravel 5).
 
-Fill secret and sitekey config in `app/config/packages/anhskohbo/no-captcha/config.php` file:
+Fill secret and sitekey config in `app/config/packages/anhskohbo/no-captcha/config.php` file:  
+You can optionally specify a [language code](https://developers.google.com/recaptcha/docs/language).
 
 ```php
 <?php
@@ -41,8 +42,13 @@ return array(
 	'secret'  => '',
 	'sitekey' => '',
 
+	'lang'    => '',
+	'enabled' => true,
+
 );
+
 ```
+By default, reCAPTCHA will be disabled while running tests. To change this, update (or delete) `app/config/packages/anhskohbo/no-captcha/testing/config.php` 
 
 ### Usage
 

--- a/src/NoCaptcha.php
+++ b/src/NoCaptcha.php
@@ -27,18 +27,26 @@ class NoCaptcha {
 	protected $lang;
 
 	/**
+	 * @var bool
+	 */
+	protected $enabled;
+
+	/**
 	 * //
-	 * 
+	 *
 	 * @param string $secret
 	 * @param string $sitekey
+	 * @param null   $lang
+	 * @param bool   $enabled
 	 */
-	public function __construct($secret, $sitekey, $lang = null)
+	public function __construct($secret, $sitekey, $lang = null, $enabled = true)
 	{
 		$this->lang = $lang;
 
 		$this->secret = $secret;
 
 		$this->sitekey = $sitekey;
+		$this->enabled = $enabled;
 	}
 
 	/**
@@ -48,6 +56,10 @@ class NoCaptcha {
 	 */
 	public function display($attributes = array())
 	{
+		if ( ! $this->enabled) {
+			return '<input type="hidden" name="g-recaptcha-response" value="1" />';
+		}
+
 		$attributes['data-sitekey'] = $this->sitekey;
 
 		$html  = '<script src="'.$this->getJsLink().'"></script>'."\n";
@@ -65,6 +77,10 @@ class NoCaptcha {
 	 */
 	public function verifyResponse($response, $clientIp = null)
 	{
+		if ( ! $this->enabled) {
+			return true;
+		}
+
 		if (empty($response)) return false;
 
 		$response = $this->sendRequestVerify(array(

--- a/src/NoCaptchaServiceProvider.php
+++ b/src/NoCaptchaServiceProvider.php
@@ -48,7 +48,8 @@ class NoCaptchaServiceProvider extends ServiceProvider {
 			return new NoCaptcha(
 				$app['config']->get('no-captcha::secret'),
 				$app['config']->get('no-captcha::sitekey'),
-				$app['config']->get('no-captcha::lang')
+				$app['config']->get('no-captcha::lang'),
+				$app['config']->get('no-captcha::enabled')
 			);
 		});
 	}

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -6,5 +6,6 @@ return array(
 	'sitekey' => '',
 
 	'lang'    => '',
+	'enabled' => true,
 
 );

--- a/src/config/testing/config.php
+++ b/src/config/testing/config.php
@@ -1,0 +1,7 @@
+<?php
+
+return array(
+
+	'enabled' => false,
+
+);


### PR DESCRIPTION
Love the package, makes reCAPTCHA crazy easy to use.

I have some Codeception tests that fill out forms (to simulate a user filling out the registration form, etc.) that obviously fail when I add reCAPTCHA, 

I added an 'enabled' config so I could disable it in the config, and a `testing` environment configuration to disable it by default for tests.