### PR TITLE
Dev master

### DIFF
--- a/src/NoCaptcha.php
+++ b/src/NoCaptcha.php
@@ -6,140 +6,161 @@ use Symfony\Component\HttpFoundation\Request;
 
 class NoCaptcha
 {
-    const CLIENT_API = 'https://www.google.com/recaptcha/api.js';
-    const VERIFY_URL = 'https://www.google.com/recaptcha/api/siteverify';
+  const CLIENT_API = 'https://www.google.com/recaptcha/api.js';
+  const VERIFY_URL = 'https://www.google.com/recaptcha/api/siteverify';
 
-    /**
-     * The recaptcha secret key.
-     *
-     * @var string
-     */
-    protected $secret;
+  /**
+  * The recaptcha secret key.
+  *
+  * @var string
+  */
+  protected $secret;
 
-    /**
-     * The recaptcha sitekey key.
-     *
-     * @var string
-     */
-    protected $sitekey;
+  /**
+  * The recaptcha sitekey key.
+  *
+  * @var string
+  */
+  protected $sitekey;
 
-    /**
-     * NoCaptcha.
-     *
-     * @param string $secret
-     * @param string $sitekey
-     */
-    public function __construct($secret, $sitekey)
-    {
-        $this->secret = $secret;
-        $this->sitekey = $sitekey;
+  /**
+  * NoCaptcha.
+  *
+  * @param string $secret
+  * @param string $sitekey
+  */
+  public function __construct($secret, $sitekey)
+  {
+    $this->secret = $secret;
+    $this->sitekey = $sitekey;
+  }
+
+  // public static function setClientApiLink = ($link) {
+  //   $this->
+  // }
+
+  /**
+  * Render HTML captcha.
+  *
+  * @return string
+  */
+  public function display($attributes = [], $lang = null, $apiParams = [])
+  {
+    $attributes['data-sitekey'] = $this->sitekey;
+
+    // Fix for older format still in use
+    if (isset($lang)) {
+      $apiParams[] = ['h1'=>$lang];
     }
 
-    /**
-     * Render HTML captcha.
-     *
-     * @return string
-     */
-    public function display($attributes = [], $lang = null)
-    {
-        $attributes['data-sitekey'] = $this->sitekey;
+    $html = '<script src="'.$this->getJsLink($apiParams).'" async defer></script>'."\n";
+    $html .= '<div class="g-recaptcha"'.$this->buildAttributes($attributes).'></div>';
 
-        $html = '<script src="'.$this->getJsLink($lang).'" async defer></script>'."\n";
-        $html .= '<div class="g-recaptcha"'.$this->buildAttributes($attributes).'></div>';
+    return $html;
+  }
 
-        return $html;
+  /**
+  * Verify no-captcha response.
+  *
+  * @param string $response
+  * @param string $clientIp
+  *
+  * @return bool
+  */
+  public function verifyResponse($response, $clientIp = null)
+  {
+    if (empty($response)) {
+      return false;
     }
 
-    /**
-     * Verify no-captcha response.
-     *
-     * @param string $response
-     * @param string $clientIp
-     *
-     * @return bool
-     */
-    public function verifyResponse($response, $clientIp = null)
-    {
-        if (empty($response)) {
-            return false;
-        }
+    $response = $this->sendRequestVerify([
+      'secret' => $this->secret,
+      'response' => $response,
+      'remoteip' => $clientIp,
+    ]);
 
-        $response = $this->sendRequestVerify([
-            'secret' => $this->secret,
-            'response' => $response,
-            'remoteip' => $clientIp,
-        ]);
+    return isset($response['success']) && $response['success'] === true;
+  }
 
-        return isset($response['success']) && $response['success'] === true;
+  /**
+  * Verify no-captcha response by Symfony Request.
+  *
+  * @param Request $request
+  *
+  * @return bool
+  */
+  public function verifyRequest(Request $request)
+  {
+    return $this->verifyResponse(
+    $request->get('g-recaptcha-response'),
+    $request->getClientIp()
+  );
+}
+
+/**
+* Get recaptcha js link.
+*
+* @return string
+*/
+public function getJsLink($params = [])
+{
+  //generated params
+  $gParams = '';
+  // Generate params if they exist
+  if ( count($params) > 0) {
+    $keys = array_keys($params);
+    foreach ($params as $key => $val) {
+      // First param begins with ? every other after is &
+      $format = ($params[$keys[0]] == $val) ? '?' : '&';
+      $gParams .= $format.$key.'='.$val;
     }
+  }
 
-    /**
-     * Verify no-captcha response by Symfony Request.
-     *
-     * @param Request $request
-     *
-     * @return bool
-     */
-    public function verifyRequest(Request $request)
-    {
-        return $this->verifyResponse(
-            $request->get('g-recaptcha-response'),
-            $request->getClientIp()
-        );
-    }
+  return static::CLIENT_API.$gParams;
+}
 
-    /**
-     * Get recaptcha js link.
-     *
-     * @return string
-     */
-    public function getJsLink($lang = null)
-    {
-        return $lang ? static::CLIENT_API.'?hl='.$lang : static::CLIENT_API;
-    }
+/**
+* Send verify request.
+*
+* @param array $query
+*
+* @return array
+*/
+protected function sendRequestVerify(array $query = [])
+{
+  // This taken from: https://github.com/google/recaptcha/blob/master/src/ReCaptcha/RequestMethod/Post.php
+  $peer_key = version_compare(PHP_VERSION, '5.6.0', '<') ? 'CN_name' : 'peer_name';
 
-    /**
-     * Send verify request.
-     *
-     * @param array $query
-     *
-     * @return array
-     */
-    protected function sendRequestVerify(array $query = [])
-    {
-        // This taken from: https://github.com/google/recaptcha/blob/master/src/ReCaptcha/RequestMethod/Post.php
-        $peer_key = version_compare(PHP_VERSION, '5.6.0', '<') ? 'CN_name' : 'peer_name';
+  $context = stream_context_create(array(
+    'http' => array(
+      'header' => "Content-type: application/x-www-form-urlencoded\r\n",
+      'method' => 'POST',
+      'content' => http_build_query($query, '', '&'),
+      'verify_peer' => true,
+      $peer_key => 'www.google.com',
+    ),
+  ));
 
-        $context = stream_context_create(array(
-            'http' => array(
-                'header' => "Content-type: application/x-www-form-urlencoded\r\n",
-                'method' => 'POST',
-                'content' => http_build_query($query, '', '&'),
-                'verify_peer' => true,
-                $peer_key => 'www.google.com',
-            ),
-        ));
+  $response = file_get_contents(static::VERIFY_URL, false, $context);
 
-        $response = file_get_contents(static::VERIFY_URL, false, $context);
+  return json_decode($response, true);
+}
 
-        return json_decode($response, true);
-    }
+/**
+* Build HTML attributes.
+*
+* @param array $attributes
+*
+* @return string
+*/
+protected function buildAttributes(array $attributes)
+{
+  $html = [];
 
-    /**
-     * Build HTML attributes.
-     *
-     * @param array $attributes
-     *
-     * @return string
-     */
-    protected function buildAttributes(array $attributes)
-    {
-        $html = [];
+  foreach ($attributes as $key => $value) {
+    $html[] = $key.'="'.$value.'"';
+  }
 
-        foreach ($attributes as $key => $value) {
-            $html[] = $key.'="'.$value.'"';
-        }
-
-        return count($html) ? ' '.implode(' ', $html) : '';
-    }
+  return count($html) ? ' '.implode(' ', $html) : '';
+}
 }

--- a/src/NoCaptcha.php
+++ b/src/NoCaptcha.php
@@ -35,10 +35,6 @@ class NoCaptcha
     $this->sitekey = $sitekey;
   }
 
-  // public static function setClientApiLink = ($link) {
-  //   $this->
-  // }
-
   /**
   * Render HTML captcha.
   *


### PR DESCRIPTION
This adds the ability to append your own parameters to the api JS link. This would save myself and alot of other people a heap of time. Some JS requires appending a custom callback function to the api url etc.. so helps alot! 

Usage for appending params is like so: 

`{!! app('captcha')->display([],null,['someParam'=>'someval123','someParam2'=>'someAdditionalvalu123123']); !!}`

Renders out like so: 

`<script src="https://www.google.com/recaptcha/api.js?someParam=someval123&amp;someParam2=someAdditionalvalu123123" async="" defer=""></script>`

Feedback apreciated. Cheers, 

Glade
