### PR TITLE
Update for multiple app('captcha')->display() on the same page - V2

### DIFF
--- a/src/NoCaptcha.php
+++ b/src/NoCaptcha.php
@@ -32,7 +32,7 @@ class NoCaptcha
     /**
      * API requested control
      */
-    protected $api_requested;
+    protected $api_requested = FALSE;
 
     /**
      * NoCaptcha.
@@ -47,7 +47,6 @@ class NoCaptcha
         $this->http = new Client([
             'timeout'  => 2.0,
         ]);
-        $this->api_requested = FALSE;
     }
 
     /**

--- a/src/NoCaptcha.php
+++ b/src/NoCaptcha.php
@@ -32,7 +32,7 @@ class NoCaptcha
     /**
      * API requested control
      */
-    protected $api_requested = false;
+    protected $api_requested = 0;
 
     /**
      * NoCaptcha.
@@ -56,15 +56,43 @@ class NoCaptcha
      */
     public function display($attributes = [], $lang = null)
     {
+        if ($this->api_requested !== 0) {
+            return 'To request multiple instances of NoCaptcha on the same page you must use the function multiple_display().';
+        }
+        
+        $this->api_requested = true;
+        
         $attributes['data-sitekey'] = $this->sitekey;
-
+        
+        $html = '<script src="'.$this->getJsLink($lang).'" async defer></script>'."\n";
+        $html .= '<div class="g-recaptcha"'.$this->buildAttributes($attributes).'></div>';
+        
+        return $html;
+    }
+    
+    /**
+     * Render multiple HTML captcha on the same page ( Explicitly render the reCAPTCHA widget ).
+     *
+     * @return string
+     */
+    public function multiple_display($attributes = [], $lang = null)
+    {
+        if ($this->api_requested === true) {
+            return 'You cannot use display() and multiple_display() from NoCaptcha on the same page.';
+        }
+        
+        $this->api_requested += 1;
+        
+        $attributes['data-sitekey'] = $this->sitekey;
+        $attributes['id'] = 'grecaptcha'.$this->api_requested;
+        
         $html = '';
-        if (empty($this->api_requested)) {
-            $this->api_requested = true;
-            $html .= '<script src="'.$this->getJsLink($lang).'" async defer></script>'."\n";
+        if ($this->api_requested === 1) {
+            $html .= '<script>function NoCaptchaCallback() { var elems = document.getElementsByClassName("g-recaptcha"); for (i=0; i<elems.length; i++) { grecaptcha.render(elems[i].id, {"sitekey" : "'.$this->sitekey.'"}); } }</script>'."\n";
+            $html .= '<script src="'.$this->getJsLink($lang).'?onload=NoCaptchaCallback&render=explicit" async defer></script>'."\n";
         }
         $html .= '<div class="g-recaptcha"'.$this->buildAttributes($attributes).'></div>';
-
+        
         return $html;
     }
 

--- a/src/NoCaptcha.php
+++ b/src/NoCaptcha.php
@@ -30,6 +30,11 @@ class NoCaptcha
     protected $http;
 
     /**
+     * API requested control
+     */
+    protected $api_requested;
+
+    /**
      * NoCaptcha.
      *
      * @param string $secret
@@ -42,6 +47,7 @@ class NoCaptcha
         $this->http = new Client([
             'timeout'  => 2.0,
         ]);
+        $this->api_requested = FALSE;
     }
 
     /**
@@ -53,7 +59,11 @@ class NoCaptcha
     {
         $attributes['data-sitekey'] = $this->sitekey;
 
-        $html = '<script src="'.$this->getJsLink($lang).'" async defer></script>'."\n";
+        $html = '';
+        if(empty($this->api_requested)){
+            $this->api_requested = TRUE;
+            $html .= '<script src="'.$this->getJsLink($lang).'" async defer></script>'."\n";
+        }
         $html .= '<div class="g-recaptcha"'.$this->buildAttributes($attributes).'></div>';
 
         return $html;

--- a/src/NoCaptcha.php
+++ b/src/NoCaptcha.php
@@ -32,7 +32,7 @@ class NoCaptcha
     /**
      * API requested control
      */
-    protected $api_requested = FALSE;
+    protected $api_requested = false;
 
     /**
      * NoCaptcha.
@@ -59,8 +59,8 @@ class NoCaptcha
         $attributes['data-sitekey'] = $this->sitekey;
 
         $html = '';
-        if(empty($this->api_requested)){
-            $this->api_requested = TRUE;
+        if (empty($this->api_requested)) {
+            $this->api_requested = true;
             $html .= '<script src="'.$this->getJsLink($lang).'" async defer></script>'."\n";
         }
         $html .= '<div class="g-recaptcha"'.$this->buildAttributes($attributes).'></div>';

--- a/src/NoCaptchaServiceProvider.php
+++ b/src/NoCaptchaServiceProvider.php
@@ -52,7 +52,7 @@ class NoCaptchaServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->app->bind('captcha', function ($app) {
+        $this->app->singleton('captcha', function ($app) {
             return new NoCaptcha(
                 $app['config']['captcha.secret'],
                 $app['config']['captcha.sitekey']


### PR DESCRIPTION
BRANCH CORRECTION OF PREVIOUS PULL REQUEST :  https://github.com/anhskohbo/no-captcha/pull/58

ORIGINAL COMMENT : 

hi!
so, after furder checking this situation, i forget that the default google reCaptcha code will automatically render only the first div/instance, so i added a function to use the "explicit" mode, with this changes to request only one noCaptcha just call display :

{!! app('captcha')->display() !!}

when usign multipla instance we should call only the functio multiple_display like this :

{!! app('captcha')->multiple_display() !!}
.....
{!! app('captcha')->multiple_display() !!}

what do you think?