### PR TITLE
Added support to render only the script tag or the captcha field.

### DIFF
--- a/src/NoCaptcha.php
+++ b/src/NoCaptcha.php
@@ -61,6 +61,36 @@ class NoCaptcha
     }
 
     /**
+     * Render captcha script tag
+     *
+     * @param null $lang
+     *
+     * @return string
+     */
+    public function displayScript($lang = null)
+    {
+        $html = '<script src="'.$this->getJsLink($lang).'" async defer></script>'."\n";
+
+        return $html;
+    }
+
+    /**
+     * Render the captcha field without the script tag.
+     *
+     * @param array $attributes
+     *
+     * @return string
+     */
+    public function displayCaptchaField($attributes = [])
+    {
+        $attributes['data-sitekey'] = $this->sitekey;
+
+        $html = '<div class="g-recaptcha"'.$this->buildAttributes($attributes).'></div>';
+
+        return $html;
+    }
+
+    /**
      * Verify no-captcha response.
      *
      * @param string $response

--- a/tests/NoCaptchaTest.php
+++ b/tests/NoCaptchaTest.php
@@ -29,4 +29,28 @@ class NoCaptchaTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($this->captcha->display([], 'vi'), $withLang);
         $this->assertEquals($this->captcha->display(['data-theme' => 'light']), $withAttrs);
     }
+
+    public function testDisplayScript()
+    {
+        $this->assertTrue($this->captcha instanceof NoCaptcha);
+
+        $simple = '<script src="https://www.google.com/recaptcha/api.js" async defer></script>'."\n";
+
+        $withLang ='<script src="https://www.google.com/recaptcha/api.js?hl=vi" async defer></script>'."\n";
+
+        $this->assertEquals($this->captcha->displayScript(), $simple);
+        $this->assertEquals($this->captcha->displayScript('vi'), $withLang);
+    }
+
+    public function testDisplayField()
+    {
+        $this->assertTrue($this->captcha instanceof NoCaptcha);
+
+        $simple = '<div class="g-recaptcha" data-sitekey="{site-key}"></div>';
+
+        $withAttrs ='<div class="g-recaptcha" data-theme="light" data-sitekey="{site-key}"></div>';
+
+        $this->assertEquals($this->captcha->displayCaptchaField(), $simple);
+        $this->assertEquals($this->captcha->displayCaptchaField(['data-theme' => 'light']), $withAttrs);
+    }
 }


### PR DESCRIPTION
As requested in issue #68 this pull requests adds the support to split the rendering of the script tag and the captcha field itself.

This is useful if you work with js frameworks, like VUE.js. In the current state you get an error, because in VUE templates are no `<script>`-tags allowed.

I also included the necessary tests.

Have a nice day,
Jordan