### PR TITLE
Added check in ServiceProvider's register and boot methods to see if …

### DIFF
--- a/src/NoCaptchaServiceProvider.php
+++ b/src/NoCaptchaServiceProvider.php
@@ -20,6 +20,13 @@ class NoCaptchaServiceProvider extends ServiceProvider
     {
         $app = $this->app;
 
+        /**
+         * no use on terminal, at least for now
+         */
+        if ($app instanceof LaravelApplication && $app->runningInConsole()) {
+            return;
+        }
+
         $this->bootConfig();
 
         $app['validator']->extend('captcha', function ($attribute, $value) use ($app) {
@@ -52,6 +59,13 @@ class NoCaptchaServiceProvider extends ServiceProvider
      */
     public function register()
     {
+        /**
+         * no use on terminal, at least for now
+         */
+        if ($this->app instanceof LaravelApplication && $this->app->runningInConsole()) {
+            return;
+        }
+        
         $this->app->singleton('captcha', function ($app) {
             return new NoCaptcha(
                 $app['config']['captcha.secret'],


### PR DESCRIPTION
…we are on terminal, then do not register and boot.

Why? because, if we add no-captcha to the project at the very beginning or say before generating application key (artisan key:generate), then artisan key:generate will throw an error of "RuntimeException No application encryption key has been specified." because of the use of Encryption class, which itself require application key.