### PR TITLE
Change domain to www.recaptcha.net

### DIFF
--- a/src/NoCaptcha.php
+++ b/src/NoCaptcha.php
@@ -7,8 +7,8 @@ use GuzzleHttp\Client;
 
 class NoCaptcha
 {
-    const CLIENT_API = 'https://www.google.com/recaptcha/api.js';
-    const VERIFY_URL = 'https://www.google.com/recaptcha/api/siteverify';
+    const CLIENT_API = 'https://www.recaptcha.net/recaptcha/api.js';
+    const VERIFY_URL = 'https://www.recaptcha.net/recaptcha/api/siteverify';
 
     /**
      * The recaptcha secret key.


### PR DESCRIPTION
As by Google's specs, the domain name needs to be changed to www.recaptcha.net for global usage, in particular China.

https://developers.google.com/recaptcha/docs/faq