### PR TITLE
solution to "build error"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: php
 
+dist: trusty
+
 php:
   - 5.5
   - 5.6


### PR DESCRIPTION
Build was failing while building with PHP 5.5. 
As default Travis CI uses Xenial distro and it does not support 5.x PHP versions correctly.
In order to solve this problem, I added 'dist:trusty' setting to .travis.yml.