### PR TITLE
Add type hints to the functions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,9 +6,9 @@
         "no-captcha",
         "captcha",
         "laravel",
-        "laravel4",
-        "laravel5",
-        "laravel6"
+        "laravel8",
+        "laravel9",
+        "laravel10"
     ],
     "license": "MIT",
     "authors": [
@@ -18,12 +18,12 @@
         }
     ],
     "require": {
-        "php": ">=5.5.5",
-        "illuminate/support": "^5.0|^6.0|^7.0|^8.0|^9.0|^10.0",
-        "guzzlehttp/guzzle": "^6.2|^7.0"
+        "php": ">=8.0.0",
+        "illuminate/support": "^8.0|^9.0|^10.0",
+        "guzzlehttp/guzzle": "^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.8|^9.5.10"
+        "phpunit/phpunit": "^9.5.10"
     },
     "autoload": {
         "psr-4": {

--- a/src/Facades/NoCaptcha.php
+++ b/src/Facades/NoCaptcha.php
@@ -8,10 +8,8 @@ class NoCaptcha extends Facade
 {
     /**
      * Get the registered name of the component.
-     *
-     * @return string
      */
-    protected static function getFacadeAccessor()
+    protected static function getFacadeAccessor(): string
     {
         return 'captcha';
     }

--- a/src/NoCaptcha.php
+++ b/src/NoCaptcha.php
@@ -12,38 +12,28 @@ class NoCaptcha
 
     /**
      * The recaptcha secret key.
-     *
-     * @var string
      */
-    protected $secret;
+    protected string $secret;
 
     /**
      * The recaptcha sitekey key.
-     *
-     * @var string
      */
-    protected $sitekey;
+    protected string $sitekey;
 
     /**
-     * @var \GuzzleHttp\Client
+     * GuzzleHttp client
      */
-    protected $http;
+    protected Client $http;
 
     /**
      * The cached verified responses.
-     *
-     * @var array
      */
-    protected $verifiedResponses = [];
+    protected array $verifiedResponses = [];
 
     /**
      * NoCaptcha.
-     *
-     * @param string $secret
-     * @param string $sitekey
-     * @param array $options
      */
-    public function __construct($secret, $sitekey, $options = [])
+    public function __construct(string $secret, string $sitekey, array $options = [])
     {
         $this->secret = $secret;
         $this->sitekey = $sitekey;
@@ -52,12 +42,8 @@ class NoCaptcha
 
     /**
      * Render HTML captcha.
-     *
-     * @param array $attributes
-     *
-     * @return string
      */
-    public function display($attributes = [])
+    public function display(array $attributes = []): string
     {
         $attributes = $this->prepareAttributes($attributes);
         return '<div' . $this->buildAttributes($attributes) . '></div>';
@@ -66,7 +52,7 @@ class NoCaptcha
     /**
      * @see display()
      */
-    public function displayWidget($attributes = [])
+    public function displayWidget(array $attributes = []): string
     {
         return $this->display($attributes);
     }
@@ -77,10 +63,8 @@ class NoCaptcha
      * @param string $formIdentifier the html ID of the form that should be submitted.
      * @param string $text the text inside the form button
      * @param array $attributes array of additional html elements
-     *
-     * @return string
      */
-    public function displaySubmit($formIdentifier, $text = 'submit', $attributes = [])
+    public function displaySubmit(string $formIdentifier, string $text = 'submit', array $attributes = []): string
     {
         $javascript = '';
         if (!isset($attributes['data-callback'])) {
@@ -102,26 +86,16 @@ class NoCaptcha
 
     /**
      * Render js source
-     *
-     * @param null $lang
-     * @param bool $callback
-     * @param string $onLoadClass
-     * @return string
      */
-    public function renderJs($lang = null, $callback = false, $onLoadClass = 'onloadCallBack')
+    public function renderJs(?string $lang = null, bool $callback = false, string $onLoadClass = 'onloadCallBack'): string
     {
         return '<script src="'.$this->getJsLink($lang, $callback, $onLoadClass).'" async defer></script>'."\n";
     }
 
     /**
      * Verify no-captcha response.
-     *
-     * @param string $response
-     * @param string $clientIp
-     *
-     * @return bool
      */
-    public function verifyResponse($response, $clientIp = null)
+    public function verifyResponse(string $response, ?string $clientIp = null): bool
     {
         if (empty($response)) {
             return false;
@@ -150,12 +124,8 @@ class NoCaptcha
 
     /**
      * Verify no-captcha response by Symfony Request.
-     *
-     * @param Request $request
-     *
-     * @return bool
      */
-    public function verifyRequest(Request $request)
+    public function verifyRequest(Request $request): bool
     {
         return $this->verifyResponse(
             $request->get('g-recaptcha-response'),
@@ -165,13 +135,8 @@ class NoCaptcha
 
     /**
      * Get recaptcha js link.
-     *
-     * @param string $lang
-     * @param boolean $callback
-     * @param string $onLoadClass
-     * @return string
      */
-    public function getJsLink($lang = null, $callback = false, $onLoadClass = 'onloadCallBack')
+    public function getJsLink(?string $lang = null, bool $callback = false, string $onLoadClass = 'onloadCallBack'): string
     {
         $client_api = static::CLIENT_API;
         $params = [];
@@ -182,11 +147,7 @@ class NoCaptcha
         return $client_api . '?'. http_build_query($params);
     }
 
-    /**
-     * @param $params
-     * @param $onLoadClass
-     */
-    protected function setCallBackParams(&$params, $onLoadClass)
+    protected function setCallBackParams(array &$params, string $onLoadClass): void
     {
         $params['render'] = 'explicit';
         $params['onload'] = $onLoadClass;
@@ -194,12 +155,8 @@ class NoCaptcha
 
     /**
      * Send verify request.
-     *
-     * @param array $query
-     *
-     * @return array
      */
-    protected function sendRequestVerify(array $query = [])
+    protected function sendRequestVerify(array $query = []): array
     {
         $response = $this->http->request('POST', static::VERIFY_URL, [
             'form_params' => $query,
@@ -210,12 +167,8 @@ class NoCaptcha
 
     /**
      * Prepare HTML attributes and assure that the correct classes and attributes for captcha are inserted.
-     *
-     * @param array $attributes
-     *
-     * @return array
      */
-    protected function prepareAttributes(array $attributes)
+    protected function prepareAttributes(array $attributes): array
     {
         $attributes['data-sitekey'] = $this->sitekey;
         if (!isset($attributes['class'])) {
@@ -228,12 +181,8 @@ class NoCaptcha
 
     /**
      * Build HTML attributes.
-     *
-     * @param array $attributes
-     *
-     * @return string
      */
-    protected function buildAttributes(array $attributes)
+    protected function buildAttributes(array $attributes): string
     {
         $html = [];
 

--- a/src/NoCaptchaServiceProvider.php
+++ b/src/NoCaptchaServiceProvider.php
@@ -16,7 +16,7 @@ class NoCaptchaServiceProvider extends ServiceProvider
     /**
      * Bootstrap the application events.
      */
-    public function boot()
+    public function boot(): void
     {
         $app = $this->app;
 
@@ -36,7 +36,7 @@ class NoCaptchaServiceProvider extends ServiceProvider
     /**
      * Booting configure.
      */
-    protected function bootConfig()
+    protected function bootConfig(): void
     {
         $path = __DIR__.'/config/captcha.php';
 
@@ -50,7 +50,7 @@ class NoCaptchaServiceProvider extends ServiceProvider
     /**
      * Register the service provider.
      */
-    public function register()
+    public function register(): void
     {
         $this->app->singleton('captcha', function ($app) {
             return new NoCaptcha(
@@ -63,10 +63,8 @@ class NoCaptchaServiceProvider extends ServiceProvider
 
     /**
      * Get the services provided by the provider.
-     *
-     * @return array
      */
-    public function provides()
+    public function provides(): array
     {
         return ['captcha'];
     }

--- a/tests/NoCaptchaTest.php
+++ b/tests/NoCaptchaTest.php
@@ -9,18 +9,18 @@ class NoCaptchaTest extends PHPUnit_Framework_TestCase
      */
     private $captcha;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->captcha = new NoCaptcha('{secret-key}', '{site-key}');
     }
 
-    public function testRequestShouldWorks()
+    public function testRequestShouldWorks(): void
     {
         $response = $this->captcha->verifyResponse('should_false');
     }
 
-    public function testJsLink()
+    public function testJsLink(): void
     {
         $this->assertTrue($this->captcha instanceof NoCaptcha);
 
@@ -33,7 +33,7 @@ class NoCaptchaTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($withCallback, $this->captcha->renderJs(null, true, 'myOnloadCallback'));
     }
 
-    public function testDisplay()
+    public function testDisplay(): void
     {
         $this->assertTrue($this->captcha instanceof NoCaptcha);
 
@@ -44,7 +44,7 @@ class NoCaptchaTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($withAttrs, $this->captcha->display(['data-theme' => 'light']));
     }
 
-    public function testdisplaySubmit()
+    public function testdisplaySubmit(): void
     {
         $this->assertTrue($this->captcha instanceof NoCaptcha);
 
@@ -57,7 +57,7 @@ class NoCaptchaTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($withAttrs . $javascript, $withAttrsResult);
     }
 
-    public function testdisplaySubmitWithCustomCallback()
+    public function testdisplaySubmitWithCustomCallback(): void
     {
         $this->assertTrue($this->captcha instanceof NoCaptcha);
 


### PR DESCRIPTION
This PR is to add type hints to the functions following the Laravel 10 trends. 

With this PR, minimum PHP version requirement will be PHP 8.
Therefore, Laravel versions before Laravel 8 will lose support.